### PR TITLE
feat: update audio output format for TextToSpeech requests

### DIFF
--- a/api/speech.go
+++ b/api/speech.go
@@ -35,7 +35,7 @@ func (az *AzureTTSClient) TextToSpeech(ctx context.Context,
 		utils.ConvertFloat32ToString(pitchValue)+"%",
 	)
 
-	req, err := az.newTTSRequest(ctx, "POST", az.TextToSpeechURL, bytes.NewBufferString(v), model.Audio16khz32kbitrateMonoMp3)
+	req, err := az.newTTSRequest(ctx, "POST", az.TextToSpeechURL, bytes.NewBufferString(v), request.AudioOutput)
 	if err != nil {
 		return respData, fmt.Errorf("tts request error %v", err)
 	}

--- a/model/properties.go
+++ b/model/properties.go
@@ -12,7 +12,7 @@ const (
 	AudioRIFF16khz16kbpsMonoSiren
 	AudioRIFF24khz16bitMonoPcm
 	AudioRAW8Bit8kHzMonoMulaw
-	AudioRAW16Bit16kHzMonoMulaw
+	AudioRAW16Bit16kHzMonoPcm
 	AudioRAW24khz16bitMonoPcm
 	AudioRAW22050hz16bitMonoPcm
 	AudioSsml16khz16bitMonoTts


### PR DESCRIPTION
- Update the audio output format in the TextToSpeech request
- Change the AudioRAW16Bit16kHzMonoMulaw to AudioRAW16Bit16kHzMonoPcm in the audio properties list